### PR TITLE
[fix] all : Upgrade project to API 55 and add required property on flexipage from API 53

### DIFF
--- a/force-app/main/default/flexipages/sfpegIconCatalog.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/sfpegIconCatalog.flexipage-meta.xml
@@ -4,6 +4,7 @@
         <itemInstances>
             <componentInstance>
                 <componentName>sfpegIconCatalogCmp</componentName>
+                <identifier>sfpegIconCatalogCmp</identifier>
             </componentInstance>
         </itemInstances>
         <name>main</name>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "51.0"
+  "sourceApiVersion": "55.0"
 }


### PR DESCRIPTION
From API 53, a new property is required on [flexipage](https://developer.salesforce.com/docs/atlas.en-us.234.0.api_meta.meta/api_meta/meta_flexipage.htm#ComponentInstance)