### PR TITLE
[fix] all : Resolve PMD errors ClassNamingConventions

### DIFF
--- a/force-app/main/default/classes/sfpegActionSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegActionSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              Action configurations registered in the sfpegAction__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegActionSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
         VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
         global sfpegActionSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
             System.debug(LoggingLevel.FINEST,'Constructor START with sfpegAction page context ' + pageContext);
             System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
             this.pageContext = pageContext;
         }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegActionSelector_CTL extends VisualEditor.DynamicPi
             System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
             return new VisualEditor.DataRow('---','N/A');
         }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
         global override VisualEditor.DynamicPickListRows getValues() {
             System.debug(LoggingLevel.FINEST,'getValues: START for sfpegAction');
-    
+
             VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
             picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
             System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
             System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
             Map<ID,sfpegAction__mdt> queries = new Map<ID,sfpegAction__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegAction__mdt 
+                    from sfpegAction__mdt
                     where Scope__c LIKE '%GLOBAL%'  ]);
             if (! String.isEmpty(pageContext.entityName)) {
                 System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
                 queries.putAll(new Map<ID,sfpegAction__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegAction__mdt 
+                        from sfpegAction__mdt
                         where Scope__c LIKE '%RECORDS%']));
                 String entityPattern = '%' + pageContext.entityName + '%';
                 queries.putAll(new Map<ID,sfpegAction__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegAction__mdt 
+                        from sfpegAction__mdt
                         where Scope__c LIKE :entityPattern]));
             }
             System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
             for (ID iter : queries.keySet()){
                 sfpegAction__mdt queryIter = queries.get(iter);
                 System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegActionTest_SVC.cls
+++ b/force-app/main/default/classes/sfpegActionTest_SVC.cls
@@ -1,5 +1,5 @@
 /***
-* @description  Simple implementation of the generic sfpegAction_SVC class for 
+* @description  Simple implementation of the generic sfpegAction_SVC class for
 *               Apex test coverage purposes.
 * @author       P-E GROS
 * @date         April 2021
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,11 +31,12 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegActionTest_SVC extends sfpegAction_SVC {
 
     public override Object execute(final Object input, final String method) {
-        System.debug('execute: START'); 
-        System.debug('execute: END'); 
+        System.debug('execute: START');
+        System.debug('execute: END');
         return true;
     }
 }

--- a/force-app/main/default/classes/sfpegAction_CTL.cls
+++ b/force-app/main/default/classes/sfpegAction_CTL.cls
@@ -5,21 +5,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegAction_CTL {
 
     /***
@@ -108,7 +109,7 @@ public with sharing class sfpegAction_CTL {
     public static List<sObject> executeDML(list<sObject> records, string operation) {
         System.debug('executeDML : START operation ' + operation);
         System.debug('executeDML : itemList provided ' + records);
-      
+
         try {
             switch on operation {
                 when 'insert' {
@@ -135,6 +136,6 @@ public with sharing class sfpegAction_CTL {
         catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'executeDML : END KO / returning error ' + e.getMessage());
             throw new AuraHandledException(e.getMessage());
-        }        
+        }
     }
 }

--- a/force-app/main/default/classes/sfpegAction_SVC.cls
+++ b/force-app/main/default/classes/sfpegAction_SVC.cls
@@ -2,28 +2,28 @@
 * @author       P-E GROS
 * @date         May 2021
 * @description  Virtual handling class used by the sfpegAction_CTL generic controller to
-*               implement custom Apex actions. 
+*               implement custom Apex actions.
 *               Provides virtual default implementations of supported methods.
 *               Default implementation throws exceptions to warn about missing implementation.
 * @see          sfpegAction_CTL
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,10 +33,11 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public virtual class sfpegAction_SVC {
 
     /***
-    * @description  Method to provide an Apex logic implementation for the 
+    * @description  Method to provide an Apex logic implementation for the
     *               sfpegAction_CTL generic controller class.
     * @param input  Context Object record containing all the input data expected
     *               by the action.
@@ -50,5 +51,5 @@ public virtual class sfpegAction_SVC {
         System.debug(LoggingLevel.ERROR,'execute: sfpegAction_SVC default implementation called.');
         throw new AuraHandledException('Execute Apex action not implemented!');
         //return null;
-    }   
+    }
 }

--- a/force-app/main/default/classes/sfpegAction_TST.cls
+++ b/force-app/main/default/classes/sfpegAction_TST.cls
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,8 +33,9 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class  sfpegAction_TST {
-    
+
     /***
     * @description Initializes the test context.
     ***/
@@ -48,7 +49,7 @@ public class  sfpegAction_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -66,7 +67,7 @@ public class  sfpegAction_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -76,9 +77,9 @@ public class  sfpegAction_TST {
     *               check OK case.
     * @see  sfpegAction_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -102,7 +103,7 @@ public class  sfpegAction_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
 
@@ -112,53 +113,53 @@ public class  sfpegAction_TST {
     * @see  sfpegAction_CTL
     * @see  sfpegAction_SVC
     ***/
-    
+
     static TestMethod void testExecuteApex() {
-        System.debug('testExecuteApex: START'); 
+        System.debug('testExecuteApex: START');
         Test.startTest();
 
         try {
 	        Object results = sfpegAction_CTL.executeApex(null, null);
-            System.debug(LoggingLevel.Error,'testExecuteApex: no error raised for for missing Apex action'); 
+            System.debug(LoggingLevel.Error,'testExecuteApex: no error raised for for missing Apex action');
             System.assert(false);
         }
         catch (Exception e) {
             System.debug('testExecuteApex: error properly raised for missing Apex action ' + e.getMessage());
-            System.assert(true);          
+            System.assert(true);
         }
 
         try {
 	        Object results = sfpegAction_CTL.executeApex('SFPEG_DUMMY_ACTION', null);
-            System.debug(LoggingLevel.Error,'testExecuteApex: no error raised for for invalid Apex action'); 
+            System.debug(LoggingLevel.Error,'testExecuteApex: no error raised for for invalid Apex action');
             System.assert(false);
         }
         catch (Exception e) {
             System.debug('testExecuteApex: error properly raised for invalid Apex action ' + e.getMessage());
-            System.assert(true);          
+            System.assert(true);
         }
-         
+
         try {
 	        Object results = sfpegAction_CTL.executeApex('sfpegActionTest_SVC.Test',null);
-            System.debug('testExecuteApex: no error raised for for proper Apex action'); 
+            System.debug('testExecuteApex: no error raised for for proper Apex action');
             System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testExecuteApex: unexpected error raised for Apex action ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         try {
 	        Object results = sfpegAction_CTL.executeApex('sfpegAction_SVC',null);
-            System.debug('testExecuteApex: no error raised for for generic Apex action'); 
+            System.debug('testExecuteApex: no error raised for for generic Apex action');
             System.assert(false);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testExecuteApex: proper error raised for generic Apex action ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
-        
+
         Test.stopTest();
-		System.debug('testExecuteApex: END'); 
+		System.debug('testExecuteApex: END');
     }
 
 
@@ -166,11 +167,11 @@ public class  sfpegAction_TST {
     * @description  Test method for the sfpegAction_CTL class, checking the "executeDML" method.
     * @see  sfpegAction_CTL
     ***/
-    
+
     static TestMethod void testExecuteDML() {
-        System.debug('testExecuteDML: START'); 
+        System.debug('testExecuteDML: START');
         Test.startTest();
-        
+
         /*List<sObject> rcdList = new List<sObject>();
         Task newRcd1 = new Task(Subject = 'Test', Status = 'Open', ActivityDate = date.newinstance(2021,01,01));
         rcdList.add(newRcd1);
@@ -186,45 +187,45 @@ public class  sfpegAction_TST {
         try {
             List<sObject> resultList = sfpegAction_CTL.executeDML(rcdList, 'insert');
             System.debug('testExecuteDML: insert done');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testExecuteDML: unexpected error raised on insert ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         newRcd1.Name = 'Test #1 Updated';
         newRcd2.Name = 'Test #2 Updated';
         try {
             List<sObject> resultList = sfpegAction_CTL.executeDML(rcdList, 'update');
-            System.debug('testExecuteDML: update done'); 
-            System.assert(true);  
+            System.debug('testExecuteDML: update done');
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testExecuteDML: unexpected error raised on update ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         try {
             List<sObject> resultList = sfpegAction_CTL.executeDML(rcdList, 'delete');
             System.debug('testExecuteDML: delete done');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testExecuteDML: unexpected error raised on insert ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         try {
             List<sObject> resultList = sfpegAction_CTL.executeDML(rcdList, 'dummy');
             System.debug(LoggingLevel.Error,'testExecuteDML: unexpected no error raised for dummy operation');
-            System.assert(false);           
+            System.assert(false);
         }
         catch(Exception e) {
             System.debug('testExecuteDML: expected error raised for dummy  operation ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
-		
+
 		Test.stopTest();
 		System.debug('testExecuteDML: END');
     }
@@ -236,18 +237,18 @@ public class  sfpegAction_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegActionSelector_CTL controller = new sfpegActionSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -262,18 +263,18 @@ public class  sfpegAction_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegActionSelector_CTL controller = new sfpegActionSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegCardListSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegCardListSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              Card List configurations registered in the sfpegCardList__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegCardListSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
         VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
         global sfpegCardListSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
             System.debug(LoggingLevel.FINEST,'Constructor START with sfpegCardList page context ' + pageContext);
             System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
             this.pageContext = pageContext;
         }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegCardListSelector_CTL extends VisualEditor.Dynamic
             System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
             return new VisualEditor.DataRow('---','N/A');
         }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
         global override VisualEditor.DynamicPickListRows getValues() {
             System.debug(LoggingLevel.FINEST,'getValues: START for sfpegCardList');
-    
+
             VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
             picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
             System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
             System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
             Map<ID,sfpegCardList__mdt> queries = new Map<ID,sfpegCardList__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegCardList__mdt 
+                    from sfpegCardList__mdt
                     where Scope__c LIKE '%GLOBAL%'  ]);
             if (! String.isEmpty(pageContext.entityName)) {
                 System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
                 queries.putAll(new Map<ID,sfpegCardList__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegCardList__mdt 
+                        from sfpegCardList__mdt
                         where Scope__c LIKE '%RECORDS%']));
                 String entityPattern = '%' + pageContext.entityName + '%';
                 queries.putAll(new Map<ID,sfpegCardList__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegCardList__mdt 
+                        from sfpegCardList__mdt
                         where Scope__c LIKE :entityPattern]));
             }
             System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
             for (ID iter : queries.keySet()){
                 sfpegCardList__mdt queryIter = queries.get(iter);
                 System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegCardList_CTL.cls
+++ b/force-app/main/default/classes/sfpegCardList_CTL.cls
@@ -5,21 +5,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegCardList_CTL {
 
     /***
@@ -46,7 +47,7 @@ public with sharing class sfpegCardList_CTL {
         System.debug(LoggingLevel.FINE,'getConfiguration: START with sfpegCardList configuration name ' + name);
 
         List<sfpegCardList__mdt> configs = [    select  Query__c, RecordIdField__c, RecordNameField__c, CardContext__c,
-                                                        IconName__c, IconNameField__c, ObjectName__c, ObjectNameField__c, 
+                                                        IconName__c, IconNameField__c, ObjectName__c, ObjectNameField__c,
                                                         CardConfig__c, CardConfigField__c, CardActions__c, CardActionsField__c,  MasterLabel
                                                 from sfpegCardList__mdt
                                                 where DeveloperName =  :name    ];

--- a/force-app/main/default/classes/sfpegCardList_TST.cls
+++ b/force-app/main/default/classes/sfpegCardList_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class sfpegCardList_TST {
-    
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class sfpegCardList_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -65,7 +66,7 @@ public class sfpegCardList_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -75,9 +76,9 @@ public class sfpegCardList_TST {
     *               check OK case.
     * @see  sfpegCard_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public class sfpegCardList_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
     /***
@@ -111,18 +112,18 @@ public class sfpegCardList_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegCardListSelector_CTL controller = new sfpegCardListSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -137,18 +138,18 @@ public class sfpegCardList_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegCardListSelector_CTL controller = new sfpegCardListSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegCardSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegCardSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              Card configurations registered in the sfpegCard__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegCardSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
         VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
         global sfpegCardSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
             System.debug(LoggingLevel.FINEST,'Constructor START with sfpegCard page context ' + pageContext);
             System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
             this.pageContext = pageContext;
         }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegCardSelector_CTL extends VisualEditor.DynamicPick
             System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
             return new VisualEditor.DataRow('---','N/A');
         }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
         global override VisualEditor.DynamicPickListRows getValues() {
             System.debug(LoggingLevel.FINEST,'getValues: START for sfpegCard');
-    
+
             VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
             picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
             System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
             System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
             Map<ID,sfpegCard__mdt> queries = new Map<ID,sfpegCard__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegCard__mdt 
+                    from sfpegCard__mdt
                     where Scope__c LIKE '%GLOBAL%'  ]);
             if (! String.isEmpty(pageContext.entityName)) {
                 System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
                 queries.putAll(new Map<ID,sfpegCard__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegCard__mdt 
+                        from sfpegCard__mdt
                         where Scope__c LIKE '%RECORDS%']));
                 String entityPattern = '%' + pageContext.entityName + '%';
                 queries.putAll(new Map<ID,sfpegCard__mdt>(
                     [   select MasterLabel,  DeveloperName
-                        from sfpegCard__mdt 
+                        from sfpegCard__mdt
                         where Scope__c LIKE :entityPattern]));
             }
             System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
             for (ID iter : queries.keySet()){
                 sfpegCard__mdt queryIter = queries.get(iter);
                 System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegCard_CTL.cls
+++ b/force-app/main/default/classes/sfpegCard_CTL.cls
@@ -5,21 +5,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegCard_CTL {
 
     /***
@@ -77,7 +78,7 @@ public with sharing class sfpegCard_CTL {
         System.debug('updateRecord: START with record ' + record);
         System.debug('updateRecord: bypass Sharing Rules? ' + bypassSharingRules);
         System.debug('updateRecord: bypass Duplicate Rules? ' + bypassDuplicateRules);
-        
+
         Database.SaveResult result = null;
         if (bypassSharingRules) {
             System.debug('updateRecord: bypassing Sharing rules');
@@ -86,7 +87,7 @@ public with sharing class sfpegCard_CTL {
         }
         else {
             System.debug('updateRecord: bypassing only Duplicate rules');
-            Database.DMLOptions dmlHeader = new Database.DMLOptions(); 
+            Database.DMLOptions dmlHeader = new Database.DMLOptions();
             dmlHeader.DuplicateRuleHeader.allowSave = true;
             dmlHeader.DuplicateRuleHeader.runAsCurrentUser = true;
             System.debug('updateRecord: DML header set to bypass alert duplicate rules ' + dmlHeader);
@@ -104,7 +105,7 @@ public with sharing class sfpegCard_CTL {
             System.debug('updateRecord (without Sharing): START');
             if (bypassDuplicateRules) {
                 System.debug('updateRecord (without Sharing): bypassing Duplicate rules');
-                Database.DMLOptions dmlHeader = new Database.DMLOptions(); 
+                Database.DMLOptions dmlHeader = new Database.DMLOptions();
                 dmlHeader.DuplicateRuleHeader.allowSave = true;
                 dmlHeader.DuplicateRuleHeader.runAsCurrentUser = true;
                 System.debug('updatupdateRecord (without Sharing): END / updating with DML header set ' + dmlHeader);

--- a/force-app/main/default/classes/sfpegCard_TST.cls
+++ b/force-app/main/default/classes/sfpegCard_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class  sfpegCard_TST {
-    
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class  sfpegCard_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -65,7 +66,7 @@ public class  sfpegCard_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -75,9 +76,9 @@ public class  sfpegCard_TST {
     *               check OK case.
     * @see  sfpegCard_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public class  sfpegCard_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
     /***
@@ -110,11 +111,11 @@ public class  sfpegCard_TST {
     ***/
 
     static TestMethod void testUpdateRecord() {
-        System.debug('testUpdateRecord: START'); 
-        sfpegTestObject__c testRcd = new sfpegTestObject__c(Name='TEST'); 
+        System.debug('testUpdateRecord: START');
+        sfpegTestObject__c testRcd = new sfpegTestObject__c(Name='TEST');
         insert testRcd;
-        System.debug('testUpdateRecord: testRcd inserted ' + testRcd); 
-    
+        System.debug('testUpdateRecord: testRcd inserted ' + testRcd);
+
         Test.startTest();
         testRcd.Name = 'TEST UPD';
         sfpegCard_CTL.updateRecord(testRcd, false, false);
@@ -133,18 +134,18 @@ public class  sfpegCard_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegCardSelector_CTL controller = new sfpegCardSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -159,18 +160,18 @@ public class  sfpegCard_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegCardSelector_CTL controller = new sfpegCardSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegIconCatalog_CTL.cls
+++ b/force-app/main/default/classes/sfpegIconCatalog_CTL.cls
@@ -9,21 +9,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2022 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,8 +33,9 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegIconCatalog_CTL {
-    
+
     /***
     * @description  Simple method to fetch configuration details for a KPI List component.
     *               It provides the display configuration as well as the actions available.
@@ -42,7 +43,7 @@ public with sharing class sfpegIconCatalog_CTL {
     *               values in the DisplayConfig__c field (depending on the user language),
     *               leveraging the replaceLabelTokens() method of the sfpegMerge_CTL class.
     * @param        name    DeveloperName of the KPI List configuration record
-    * @return       Object  sfpegKpiList__mdt record with DisplayConfig__c, 
+    * @return       Object  sfpegKpiList__mdt record with DisplayConfig__c,
     *               MasterLabel fields filled in.
     * @exception    AuraHandledException    Raised if no configuration found for the provided name
     ***/
@@ -64,7 +65,7 @@ public with sharing class sfpegIconCatalog_CTL {
             }
             nameTokens.get(nameMatcher.group(1)).add(nameMatcher.group(2));
         }
-        
+
         System.debug('getIconList: END with ' + nameTokens);
         return nameTokens;
     }

--- a/force-app/main/default/classes/sfpegIconCatalog_TST.cls
+++ b/force-app/main/default/classes/sfpegIconCatalog_TST.cls
@@ -6,21 +6,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2022 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +31,9 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class  sfpegIconCatalog_TST {
-    
+
     /***
     * @description Initializes the test context.
     ***/
@@ -46,7 +47,7 @@ public class  sfpegIconCatalog_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -64,7 +65,7 @@ public class  sfpegIconCatalog_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -72,9 +73,9 @@ public class  sfpegIconCatalog_TST {
     * @description  Test method for the sfpegIconCatalog_CTL class, checking the "getIconList" method
     * @see  sfpegIconCatalog_CTL
     ***/
-    
+
     static TestMethod void testGetIconList() {
-        System.debug('testGetIconList: START'); 
+        System.debug('testGetIconList: START');
         Test.startTest();
 
         try {
@@ -88,6 +89,6 @@ public class  sfpegIconCatalog_TST {
         }
 
         Test.stopTest();
-        System.debug('testGetConfiguration: END');    
+        System.debug('testGetConfiguration: END');
     }
 }

--- a/force-app/main/default/classes/sfpegKpiListSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegKpiListSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              KPI List configurations registered in the sfpegKpiList__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegKpiListSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
     VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
     global sfpegKpiListSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
         System.debug(LoggingLevel.FINEST,'Constructor START with sfpegKpiList page context ' + pageContext);
         System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
         this.pageContext = pageContext;
     }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegKpiListSelector_CTL extends VisualEditor.DynamicP
         System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
         return new VisualEditor.DataRow('---','N/A');
     }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
     global override VisualEditor.DynamicPickListRows getValues() {
         System.debug(LoggingLevel.FINEST,'getValues: START for sfpegKpiList');
-    
+
         VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
         picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
         System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
         System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
         Map<ID,sfpegKpiList__mdt> queries = new Map<ID,sfpegKpiList__mdt>(
             [   select MasterLabel,  DeveloperName
-                from sfpegKpiList__mdt 
+                from sfpegKpiList__mdt
                 where Scope__c LIKE '%GLOBAL%'  ]);
         if (! String.isEmpty(pageContext.entityName)) {
             System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
             queries.putAll(new Map<ID,sfpegKpiList__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegKpiList__mdt 
+                    from sfpegKpiList__mdt
                     where Scope__c LIKE '%RECORDS%']));
             String entityPattern = '%' + pageContext.entityName + '%';
             queries.putAll(new Map<ID,sfpegKpiList__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegKpiList__mdt 
+                    from sfpegKpiList__mdt
                     where Scope__c LIKE :entityPattern]));
         }
         System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
         for (ID iter : queries.keySet()){
             sfpegKpiList__mdt queryIter = queries.get(iter);
             System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegKpiList_CTL.cls
+++ b/force-app/main/default/classes/sfpegKpiList_CTL.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +31,9 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegKpiList_CTL {
-    
+
     /***
     * @description  Simple method to fetch configuration details for a KPI List component.
     *               It provides the display configuration as well as the actions available.
@@ -40,7 +41,7 @@ public with sharing class sfpegKpiList_CTL {
     *               values in the DisplayConfig__c field (depending on the user language),
     *               leveraging the replaceLabelTokens() method of the sfpegMerge_CTL class.
     * @param        name    DeveloperName of the KPI List configuration record
-    * @return       Object  sfpegKpiList__mdt record with DisplayConfig__c, 
+    * @return       Object  sfpegKpiList__mdt record with DisplayConfig__c,
     *               MasterLabel fields filled in.
     * @exception    AuraHandledException    Raised if no configuration found for the provided name
     ***/

--- a/force-app/main/default/classes/sfpegKpiList_TST.cls
+++ b/force-app/main/default/classes/sfpegKpiList_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class  sfpegKpiList_TST {
-    
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class  sfpegKpiList_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -65,7 +66,7 @@ public class  sfpegKpiList_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -75,9 +76,9 @@ public class  sfpegKpiList_TST {
     *               check OK case.
     * @see  sfpegKpiList_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public class  sfpegKpiList_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
 
@@ -112,18 +113,18 @@ public class  sfpegKpiList_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegKpiListSelector_CTL controller = new sfpegKpiListSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -138,18 +139,18 @@ public class  sfpegKpiList_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegKpiListSelector_CTL controller = new sfpegKpiListSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegListQuery_SVC.cls
+++ b/force-app/main/default/classes/sfpegListQuery_SVC.cls
@@ -2,28 +2,28 @@
 * @author       P-E GROS
 * @date         May 2021
 * @description  Virtual handling class used by the sfpegList_CTL generic controller to
-*               implement custom Apex queries. 
+*               implement custom Apex queries.
 *               Provides virtual default implementations of supported methods.
 *               Default implementation throws exceptions to warn about missing implementation.
 * @see          sfpegList_CTL
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,10 +33,11 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public virtual class sfpegListQuery_SVC {
 
     /***
-    * @description  Method to overide in Apex the default SOQL query implementation of the 
+    * @description  Method to overide in Apex the default SOQL query implementation of the
     *               sfpegList_CTL class.
     * @param input  Context Object record containing all the input data expected
     *               by the query.
@@ -50,7 +51,7 @@ public virtual class sfpegListQuery_SVC {
         System.debug(LoggingLevel.ERROR,'getData: sfpegListQuery_SVC default implementation called.');
         throw new AuraHandledException('GetData Query action not implemented!');
         //return null;
-    }  
+    }
 
     /***
     * @description  Method to overide in Apex the default SOQL implementation of the sfpegList_CTL class
@@ -67,7 +68,7 @@ public virtual class sfpegListQuery_SVC {
         System.debug(LoggingLevel.ERROR,'getCount: sfpegListQuery_SVC default implementation called.');
         throw new AuraHandledException('GetCount Query action not implemented!');
         //return null;
-    }  
+    }
 
     /***
     * @description  Method to overide in Apex the default SOQL implementation of the sfpegList_CTL class
@@ -85,5 +86,5 @@ public virtual class sfpegListQuery_SVC {
         System.debug(LoggingLevel.ERROR,'getPaginatedData: sfpegListQuery_SVC default implementation called.');
         throw new AuraHandledException('getPaginatedData: Query action not implemented!');
         //return null;
-    }    
+    }
 }

--- a/force-app/main/default/classes/sfpegListSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegListSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              List configurations registered in the sfpegList__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegListSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
     VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
     global sfpegListSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
         System.debug(LoggingLevel.FINEST,'Constructor START with sfpegList page context ' + pageContext);
         System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
         this.pageContext = pageContext;
     }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegListSelector_CTL extends VisualEditor.DynamicPick
         System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
         return new VisualEditor.DataRow('---','N/A');
     }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
     global override VisualEditor.DynamicPickListRows getValues() {
         System.debug(LoggingLevel.FINEST,'getValues: START for sfpegList');
-    
+
         VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
         picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
         System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
         System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
         Map<ID,sfpegList__mdt> queries = new Map<ID,sfpegList__mdt>(
             [   select MasterLabel,  DeveloperName
-                from sfpegList__mdt 
+                from sfpegList__mdt
                 where Scope__c LIKE '%GLOBAL%'  ]);
         if (! String.isEmpty(pageContext.entityName)) {
             System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
             queries.putAll(new Map<ID,sfpegList__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegList__mdt 
+                    from sfpegList__mdt
                     where Scope__c LIKE '%RECORDS%']));
             String entityPattern = '%' + pageContext.entityName + '%';
             queries.putAll(new Map<ID,sfpegList__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegList__mdt 
+                    from sfpegList__mdt
                     where Scope__c LIKE :entityPattern]));
         }
         System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
         for (ID iter : queries.keySet()){
             sfpegList__mdt queryIter = queries.get(iter);
             System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegListTest_SVC.cls
+++ b/force-app/main/default/classes/sfpegListTest_SVC.cls
@@ -1,5 +1,5 @@
 /***
-* @description  Simple implementation of the generic sfpegListQuery_SVC class for 
+* @description  Simple implementation of the generic sfpegListQuery_SVC class for
 *               Apex test coverage purposes.
 * @author       P-E GROS
 * @date         April 2021
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,54 +31,55 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegListTest_SVC extends sfpegListQuery_SVC {
 
     public override List<Object> getData(final Object input, final String query) {
-        System.debug('getData: START (Apex) with query ' + query); 
+        System.debug('getData: START (Apex) with query ' + query);
 
         if (query == 'TEST') {
-            System.debug('getData: fetching test records'); 
+            System.debug('getData: fetching test records');
             List<Object> resultList = (List<Object>) [select Name from sfpegTestObject__c];
-            System.debug('getData: END OK returning ' + resultList); 
+            System.debug('getData: END OK returning ' + resultList);
             return resultList;
         }
-        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name '); 
+        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name ');
         throw new DmlException('Missing method name');
     }
 
     public override Integer getCount(final Object input, final String query) {
-        System.debug('getCount: START (Apex) with query ' + query); 
+        System.debug('getCount: START (Apex) with query ' + query);
 
         if (query == 'TEST') {
-            System.debug('getCount: fetching test records'); 
+            System.debug('getCount: fetching test records');
             Integer result = [select count() from sfpegTestObject__c];
-            System.debug('getCount: END OK returning ' + result); 
+            System.debug('getCount: END OK returning ' + result);
             return result;
         }
-        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name '); 
+        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name ');
         throw new DmlException('Missing method name');
     }
 
     public override List<Object> getPaginatedData(final Object input, final String query, final String lastValue) {
-        System.debug('getPaginatedData: START (Apex) with query ' + query); 
-        System.debug('getPaginatedData: query is ' + query); 
-        System.debug('getPaginatedData: lastValue is ' + lastValue); 
+        System.debug('getPaginatedData: START (Apex) with query ' + query);
+        System.debug('getPaginatedData: query is ' + query);
+        System.debug('getPaginatedData: lastValue is ' + lastValue);
 
         if (query == 'TEST') {
             if (lastValue == null) {
-                System.debug('getPaginatedData: fetching page #1 of test records'); 
+                System.debug('getPaginatedData: fetching page #1 of test records');
                 List<Object> resultList = (List<Object>) [select Name, Owner.Name from sfpegTestObject__c order by Id asc limit 2];
-                 System.debug('getPaginatedData: END OK returning ' + resultList); 
+                 System.debug('getPaginatedData: END OK returning ' + resultList);
                 return resultList;
             }
             else {
-                System.debug('getPaginatedData: fetching page #2 of test records'); 
+                System.debug('getPaginatedData: fetching page #2 of test records');
                 List<Object> resultList = (List<Object>) [select Name, Owner.Name from sfpegTestObject__c where Id > :lastValue order by Id asc limit 2];
-                 System.debug('getPaginatedData: END OK returning ' + resultList); 
+                 System.debug('getPaginatedData: END OK returning ' + resultList);
                 return resultList;
             }
         }
-        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name '); 
+        System.debug(LoggingLevel.Error,'getData: END KO / Missing method name ');
         throw new DmlException('Missing method name');
     }
 }

--- a/force-app/main/default/classes/sfpegList_CTL.cls
+++ b/force-app/main/default/classes/sfpegList_CTL.cls
@@ -9,21 +9,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegList_CTL {
 
     /***
@@ -53,7 +54,7 @@ public with sharing class sfpegList_CTL {
     public static Object getConfiguration(final String name) {
         System.debug(LoggingLevel.FINE,'getConfiguration: START with sfpegList configuration name ' + name);
 
-        List<sfpegList__mdt> configs = [    SELECT MasterLabel, DisplayType__c, DisplayConfig__c, QueryInput__c, DoPagination__c, QueryOrderBy__c,  FlattenResults__c, RowActions__c 
+        List<sfpegList__mdt> configs = [    SELECT MasterLabel, DisplayType__c, DisplayConfig__c, QueryInput__c, DoPagination__c, QueryOrderBy__c,  FlattenResults__c, RowActions__c
                                             FROM sfpegList__mdt
                                             WHERE DeveloperName =  :name];
         if ((configs == null) || (configs.size() != 1)) {
@@ -85,7 +86,7 @@ public with sharing class sfpegList_CTL {
     }
 
     /***
-    * @description  Standard method to fetch the list of records corresponding to a 
+    * @description  Standard method to fetch the list of records corresponding to a
     *               preconfigured sfpegList__mdt query record in a specific context.
     *               SOQL, SOSL and Apex query types are supported.
     *               All records are merge in a single list in case of SOSL.
@@ -208,7 +209,7 @@ public with sharing class sfpegList_CTL {
 
     /***
     * @description  If lazy loading is configured on the List LWC component, all records are not
-    *               returned at once. In such a case the getData() method is not used but 2 
+    *               returned at once. In such a case the getData() method is not used but 2
     *               separate methods arre available to fetch the total number of results and
     *               each result set independently.
     *               This method meets the first need.
@@ -265,7 +266,7 @@ public with sharing class sfpegList_CTL {
 
     /***
     * @description  If lazy loading is configured on the List LWC component, all records are not
-    *               returned at once. In such a case the getData() method is not used but 2 
+    *               returned at once. In such a case the getData() method is not used but 2
     *               separate methods arre available to fetch the total number of results and
     *               each result set independently.
     *               This method meets the second need, an offset being provided to progressively
@@ -289,7 +290,7 @@ public with sharing class sfpegList_CTL {
 
         if (query.QueryType__c == 'SOQL') {
             System.debug(LoggingLevel.FINE,'getPaginatedData: executing count query ' + query.QuerySOQL__c);
-            
+
             if (!(query.QuerySOQL__c).contains('{{{PAGE}}}')) {
                 System.debug(LoggingLevel.WARN,'getPaginatedData: END / KO - Missing {{{PAGE}}} key in configured SOQL query');
                 throw new AuraHandledException('Paginated SOQL Query failure: Missing {{{PAGE}}} key in configured query');
@@ -342,7 +343,7 @@ public with sharing class sfpegList_CTL {
     /***
     * @description Private utility method to fetch processing information for a List
     *              query configuration, given its developer Name.
-    * @param       name             Dev Name of the Query configuration record 
+    * @param       name             Dev Name of the Query configuration record
     * @return      sfpegList__mdt   Query execution details (depending on type)
     * @exception   AuraHandledException If no Configuration found.
     ***/
@@ -350,7 +351,7 @@ public with sharing class sfpegList_CTL {
     private static sfpegList__mdt getConfig(final String name) {
         System.debug(LoggingLevel.FINE,'getConfig: START for name ' + name);
 
-        List<sfpegList__mdt> configs = [    SELECT MasterLabel, QueryType__c, QueryClass__c, QuerySOQL__c, QueryCount__c, QueryOrderBy__c, QueryOrder__c, BypassSharing__c  
+        List<sfpegList__mdt> configs = [    SELECT MasterLabel, QueryType__c, QueryClass__c, QuerySOQL__c, QueryCount__c, QueryOrderBy__c, QueryOrder__c, BypassSharing__c
                                             FROM sfpegList__mdt
                                             WHERE DeveloperName =  :name];
         if ((configs == null) || (configs.size() != 1)) {
@@ -426,7 +427,7 @@ public with sharing class sfpegList_CTL {
         //System.debug(LoggingLevel.FINEST,'getClassInstance: className set '  + className);
         //System.debug(LoggingLevel.FINEST,'getClassInstance: methodName set ' + methodName);
         System.debug(LoggingLevel.FINEST,'getClassInstance: resultMap init ' + resultMap);
-      
+
         Type actionClass = Type.forName(className);
         if (null == actionClass) {
             System.debug(LoggingLevel.WARN,'getClassInstance: END KO / action handler not found for action ' + actionName);
@@ -440,7 +441,7 @@ public with sharing class sfpegList_CTL {
     }
 
     /***
-    * @description  Private utility method to initialize a pagination clause, as a set of 
+    * @description  Private utility method to initialize a pagination clause, as a set of
     *               specific merge tokens & values. For now, only a {{{PAGE}}} token is
     *               considered / initialized.
     * @param        fieldName           API Name of the field used for pagination
@@ -478,11 +479,11 @@ public with sharing class sfpegList_CTL {
     /***
     * @description  Private utility method to fetch the SLDS icon name related to a custom SObject.
     *               It parses all tabs incuded in all apps to try and find the SLDS svg icon name
-    *               associated to teh custom object tab. 
+    *               associated to teh custom object tab.
     *               The object tab should be included at least in one of the apps to become avvailable.
-    *               A default 'custom9' value is returned by default. 
+    *               A default 'custom9' value is returned by default.
     * @param        objectName  API Name of the SObject
-    * @return       String      customXX name of the SLDS icon related 
+    * @return       String      customXX name of the SLDS icon related
     * @exception    none
     ***/
     @TestVisible
@@ -496,12 +497,12 @@ public with sharing class sfpegList_CTL {
             List<Schema.DescribeTabResult> iterTabs = iter.getTabs();
             for (Schema.DescribeTabResult iterTab : iterTabs) {
                 if (iterTab.isCustom()) {
-                    System.debug('getCustomObjectIcon: processing Tab ' + iterTab.getSObjectName()); 
+                    System.debug('getCustomObjectIcon: processing Tab ' + iterTab.getSObjectName());
                     if (iterTab.getSObjectName() == objectName) {
                         System.debug('getCustomObjectIcon: fetching icon ID');
                         List<Schema.DescribeIconResult> iterIcons = iterTab.getIcons();
                         for (Schema.DescribeIconResult iterIcon : iterIcons) {
-                            //System.debug('getData: ' + ' # ' + iterIcon.getContentType()); 
+                            //System.debug('getData: ' + ' # ' + iterIcon.getContentType());
                             if (iterIcon.getContentType() == 'image/svg+xml') {
                                 Integer lastSlash = (iterIcon.getUrl()).lastIndexOf('/') + 1;
                                 Integer lastDot = (iterIcon.getUrl()).lastIndexOf('.');
@@ -514,7 +515,7 @@ public with sharing class sfpegList_CTL {
                     }
                     else {
                         System.debug('getCustomObjectIcon: ignored (different object)');
-                    } 
+                    }
                 }
                 else {
                     System.debug('getCustomObjectIcon: ignored (standard object)');
@@ -529,7 +530,7 @@ public with sharing class sfpegList_CTL {
     * @description  Private utility method to execute a SOQL query
     * @param        query           SOQL query to execute
     * @param        bypassSharing   Boolean flag to bypass sharing
-    * @return       List<sObject>   Result of the SOQL query 
+    * @return       List<sObject>   Result of the SOQL query
     * @exception    none
     ***/
     @TestVisible
@@ -551,7 +552,7 @@ public with sharing class sfpegList_CTL {
     * @description  Private utility method to execute a SOQL count query
     * @param        query           SOQL count query to execute
     * @param        bypassSharing   Boolean flag to bypass sharing
-    * @return       Integer         Result of the SOQL count query 
+    * @return       Integer         Result of the SOQL count query
     * @exception    none
     ***/
     @TestVisible
@@ -573,7 +574,7 @@ public with sharing class sfpegList_CTL {
     * @description  Private utility method to execute a SOQL query
     * @param        query           SOSL query to execute
     * @param        bypassSharing   Boolean flag to bypass sharing
-    * @return       List<List<sObject>> Result of the SOSL query 
+    * @return       List<List<sObject>> Result of the SOSL query
     * @exception    none
     ***/
     @TestVisible

--- a/force-app/main/default/classes/sfpegList_TST.cls
+++ b/force-app/main/default/classes/sfpegList_TST.cls
@@ -7,21 +7,21 @@
 * @see         sfpegListSelector_CTL
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
-public class  sfpegList_TST {
-    
+@SuppressWarnings('PMD.ClassNamingConventions')
+public class sfpegList_TST {
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class  sfpegList_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -65,7 +66,7 @@ public class  sfpegList_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         /*
         List<sfpegTestObject__c> rcdList = new List<sfpegTestObject__c>();
         rcdList.add(new sfpegTestObject__c(Name='TEST #1'));
@@ -76,7 +77,7 @@ public class  sfpegList_TST {
         insert rcdList;
         System.debug('testSetup: test records inserted ' + rcdList);
 		*/
-        
+
         System.debug('testSetup: END');
     }
 
@@ -86,9 +87,9 @@ public class  sfpegList_TST {
     *               check OK case.
     * @see  sfpegList_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -112,23 +113,23 @@ public class  sfpegList_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
-    
+
     /***
     * @description  Test method for the sfpegList_CTL class, checking the "getData" method.
-    *               It relies on the standard "sfpegTestSoql" metadata record to check the SOQL 
+    *               It relies on the standard "sfpegTestSoql" metadata record to check the SOQL
     *               OK case and on the "sfpegTestApex" one (relying on the sfpegListTest_SVC class)
     *               to check the Apex cases.
     * @see  sfpegList_CTL
     * @see  sfpegListTest_SVC
     ***/
-    
+
     static TestMethod void testGetData() {
-        System.debug('testGetData: START'); 
+        System.debug('testGetData: START');
         Test.startTest();
-        
+
         List<sfpegTestObject__c> rcdList = new List<sfpegTestObject__c>();
         rcdList.add(new sfpegTestObject__c(Name='TEST #1'));
         rcdList.add(new sfpegTestObject__c(Name='TEST #2'));
@@ -141,81 +142,81 @@ public class  sfpegList_TST {
         Object inputData = (Object) (new Map<Object,Object>{'OBJECT' => 'sfpegTestObject__c'});
         System.debug('testGetData: inputData init ' + inputData);
 
-        // Wrong Name case 
+        // Wrong Name case
         try {
             List<Object> resultList = sfpegList_CTL.getData('DUMMY_LIST',null);
             System.debug(LoggingLevel.Error,'testGetData: no error raised for dummy List config name');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetData: exception properly raised for dummy List config name ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // Missing Input case 
+        // Missing Input case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoql',null);
             System.debug(LoggingLevel.Error,'testGetData: no error raised for missing input');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetData: exception properly raised for missing input ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
         // Bad SOQL
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoqlKO',inputData);
             System.debug(LoggingLevel.Error,'testGetData: no error raised for bad SOQL');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetData: exception properly raised for bad SOQL ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // SOQL OK case 
+        // SOQL OK case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoql',inputData);
             System.debug('testGetData: sfpegTestSoql List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetData: exception raised for sfpegTestSoql List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
-        // SOQL Bypass OK case 
+        // SOQL Bypass OK case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoqlBypass',inputData);
             System.debug('testGetData: sfpegTestSoqlBypass List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetData: exception raised for sfpegTestSoqlBypass List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
-        // Apex OK case 
+        // Apex OK case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestApex',inputData);
             System.debug('testGetData: sfpegTestApex List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetData: exception raised for sfpegTestApex List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
-        // Apex KO case 
+        // Apex KO case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestApexUnknown',inputData);
             System.debug(LoggingLevel.Error,'testGetData: no error raised for bad Apex class');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetData: error properly raised for unknown class ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
         // Added because SOSL does not work in test classes otherwise.
@@ -226,37 +227,37 @@ public class  sfpegList_TST {
         System.debug('testGetData: sfpegTessetSearchResults init ' + setSearchResults);
         Test.setFixedSearchResults(setSearchResults);
 
-        // SOSL OK case 
+        // SOSL OK case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSosl',inputData);
             System.debug('testGetData: sfpegTestSosl List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetData: exception raised for sfpegTestSosl List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         // Bad SOSL
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoslKO',inputData);
             System.debug(LoggingLevel.Error,'testGetData: no error raised for unsupported SOSL ');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetData: exception properly raised for unsupported SOSL ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // SOSL Bypass OK case 
+        // SOSL Bypass OK case
         try {
             List<Object> resultList = sfpegList_CTL.getData('sfpegTestSoslBypass',inputData);
             System.debug('testGetData: sfpegTestSoslBypass List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetData: exception raised for sfpegTestSoslBypass List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         Test.stopTest();
@@ -265,17 +266,17 @@ public class  sfpegList_TST {
 
     /***
     * @description  Test method for the sfpegList_CTL class, checking the "getCount" method.
-    *               It relies on the standard "sfpegTestSoqlPaginated" metadata record to check the SOQL 
+    *               It relies on the standard "sfpegTestSoqlPaginated" metadata record to check the SOQL
     *               OK case and on the "sfpegTestApexPaginated" one (relying on the sfpegListTest_SVC class)
     *               to check the Apex cases.
     * @see  sfpegList_CTL
     * @see  sfpegListTest_SVC
     ***/
-    
+
     static TestMethod void testGetCount() {
-        System.debug('testGetCount: START'); 
+        System.debug('testGetCount: START');
         Test.startTest();
-        
+
         List<sfpegTestObject__c> rcdList = new List<sfpegTestObject__c>();
         rcdList.add(new sfpegTestObject__c(Name='TEST #1'));
         rcdList.add(new sfpegTestObject__c(Name='TEST #2'));
@@ -288,37 +289,37 @@ public class  sfpegList_TST {
         Object inputData = (Object) (new Map<Object,Object>{'OBJECT' => 'sfpegTestObject__c'});
         System.debug('testGetCount: inputData init ' + inputData);
 
-        // Wrong Name case 
+        // Wrong Name case
         try {
             Integer rcdCount = sfpegList_CTL.getCount('DUMMY_LIST',null);
             System.debug(LoggingLevel.Error,'testGetCount: no error raised for dummy List config name');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetCount: exception properly raised for dummy List config name ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // Missing Input case 
+        // Missing Input case
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestSoqlPaginated',null);
             System.debug(LoggingLevel.Error,'testGetCount: no error raised for missing input');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetCount: exception properly raised for missing input ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // Wrong Type SOSL 
+        // Wrong Type SOSL
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestSosl',null);
             System.debug(LoggingLevel.Error,'testGetCount: no error raised for SOSL ');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetCount: exception properly raised for SOSL ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
         // Bad Paginated SOQL
@@ -326,61 +327,61 @@ public class  sfpegList_TST {
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestSoqlPaginatedKO',inputData);
             System.debug(LoggingLevel.Error,'testGetPaginatedData: no error raised for bad SOQL count');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetPaginatedData: exception properly raised for bad SOQL count ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // SOQL OK case 
+        // SOQL OK case
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestSoqlPaginated',inputData);
             System.debug('testGetCount: sfpegTestSoqlPaginated List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetCount: exception raised for sfpegTestSoqlPaginated List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
-        // SOQL Bypass OK case 
+        // SOQL Bypass OK case
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestSoqlPaginatedBypass',inputData);
             System.debug('testGetCount: sfpegTestSoqlPaginatedBypass List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetCount: exception raised for sfpegTestSoqlPaginatedBypass List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
-        // Apex OK case 
+        // Apex OK case
         try {
             Integer rcdCount = sfpegList_CTL.getCount('sfpegTestApexPaginated',inputData);
             System.debug('testGetCount: sfpegTestApexPaginated List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetCount: exception raised for sfpegTestApexPaginated List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
-		
+
 		Test.stopTest();
 		System.debug('testGetCount: END');
     }
 
     /***
     * @description  Test method for the sfpegList_CTL class, checking the "getPaginatedData" method.
-    *               It relies on the standard "sfpegTestSoqlPaginated" metadata record to check the SOQL 
+    *               It relies on the standard "sfpegTestSoqlPaginated" metadata record to check the SOQL
     *               OK case and on the "sfpegTestApexPaginated" one (relying on the sfpegListTest_SVC class)
     *               to check the Apex cases.
     * @see  sfpegList_CTL
     * @see  sfpegListTest_SVC
     ***/
-    
+
     static TestMethod void testGetPaginatedData() {
-        System.debug('testGetPaginatedData: START'); 
+        System.debug('testGetPaginatedData: START');
         Test.startTest();
 
         List<sfpegTestObject__c> rcdList = new List<sfpegTestObject__c>();
@@ -391,30 +392,30 @@ public class  sfpegList_TST {
         rcdList.add(new sfpegTestObject__c(Name='TEST #5'));
         insert rcdList;
         System.debug('testGetPaginatedData: test records inserted ' + rcdList);
-        
+
         Object inputData = (Object) (new Map<Object,Object>{'OBJECT' => 'sfpegTestObject__c'});
         System.debug('testGetPaginatedData: inputData init ' + inputData);
 
-        // Wrong Name case 
+        // Wrong Name case
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('DUMMY_LIST',null,null);
             System.debug(LoggingLevel.Error,'testGetPaginatedData: no error raised for dummy List config name');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetPaginatedData: exception properly raised for dummy List config name ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
-        // Missing Input case 
+        // Missing Input case
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('sfpegTestSoqlPaginated',null,null);
             System.debug(LoggingLevel.Error,'testGetPaginatedData: no error raised for missing input');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetPaginatedData: exception properly raised for missing input ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
         // Wrong Type (SOSL)
@@ -422,22 +423,22 @@ public class  sfpegList_TST {
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('sfpegTestSosl',inputData,lastRecordId);
             System.debug(LoggingLevel.Error,'testGetPaginatedData: no error raised for bad type (SOSL)');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetPaginatedData: exception properly raised for bad type (SOSL) ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
         // Bad Paginated SOQL
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('sfpegTestSoqlPaginatedKO',inputData,lastRecordId);
             System.debug(LoggingLevel.Error,'testGetPaginatedData: no error raised for bad paginated SOQL');
-            System.assert(false);  
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetPaginatedData: exception properly raised for bad paginated SOQL ' + e.getMessage());
-            System.assert(true);           
+            System.assert(true);
         }
 
 
@@ -449,11 +450,11 @@ public class  sfpegList_TST {
             System.debug('testGetPaginatedData: resultSize is ' + resultSize);
             lastRecordId = ((sfpegTestObject__c)(resultList.get(resultSize - 1))).Id;
             System.debug('testGetPaginatedData: lastRecordId updated ' + lastRecordId);
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetCount: exception raised for sfpegTestSoqlPaginated List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         // SOQL OK case - Second page
@@ -462,22 +463,22 @@ public class  sfpegList_TST {
             System.debug('testGetPaginatedData: sfpegTestSoqlPaginated List config properly executed on page #2');
             Integer resultSize = resultList.size();
             System.debug('testGetPaginatedData: resultSize is ' + resultSize);
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetPaginatedData: exception raised for sfpegTestSoqlPaginated List on page #2 ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         // SOQL OK case - First page
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('sfpegTestSoqlPaginatedBypass',inputData,null);
             System.debug('testGetPaginatedData: sfpegTestSoqlPaginatedBypass List config properly executed');
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetCount: exception raised for sfpegTestSoqlPaginatedBypass List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         // Apex OK case - First page
@@ -489,13 +490,13 @@ public class  sfpegList_TST {
             System.debug('testGetPaginatedData: resultSize is ' + resultSize);
             lastRecordId = ((sfpegTestObject__c)(resultList.get(resultSize - 1))).Id;
             System.debug('testGetPaginatedData: lastRecordId updated ' + lastRecordId);
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetPaginatedData: exception raised for sfpegTestApexPaginated List ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
-		
+
         // Apex OK case - Second page
         try {
             List<Object> resultList = sfpegList_CTL.getPaginatedData('sfpegTestApexPaginated',inputData,lastRecordId);
@@ -504,11 +505,11 @@ public class  sfpegList_TST {
             System.debug('testGetPaginatedData: resultSize is ' + resultSize);
             lastRecordId = ((sfpegTestObject__c)(resultList.get(resultSize - 1))).Id;
             System.debug('testGetPaginatedData: lastRecordId updated ' + lastRecordId);
-            System.assert(true);  
+            System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetPaginatedData: exception raised for sfpegTestApexPaginated List on page #2 ' + e.getMessage());
-            System.assert(false);           
+            System.assert(false);
         }
 
         Test.stopTest();
@@ -522,50 +523,50 @@ public class  sfpegList_TST {
     ***/
 
     static TestMethod void testPrivateMethods() {
-        System.debug('testPrivateMethods: START'); 
+        System.debug('testPrivateMethods: START');
         Test.startTest();
 
         // mergeQuery() errors
         try {
             sfpegList_CTL.mergeQuery(null,null);
             System.debug(LoggingLevel.Error,'testPrivateMethods: no exception raised for mergeQuery with bad params ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testPrivateMethods: exception properly raised for mergeQuery with bad params ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         // getClassInstance() errors
         try {
             sfpegList_CTL.getClassInstance(null);
             System.debug(LoggingLevel.Error,'testPrivateMethods: no exception raised for getClassInstance with missing action name ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testPrivateMethods: exception properly raised for getClassInstance with missing action name ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         try {
             sfpegList_CTL.getClassInstance('DUMMY_CLASS');
             System.debug(LoggingLevel.Error,'testPrivateMethods: no exception raised for getClassInstance with dummy action name ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testPrivateMethods: exception properly raised for getClassInstance with dummy action name ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         // initPagination() errors
         try {
             sfpegList_CTL.initPagination(null,null,null);
             System.debug(LoggingLevel.Error,'testPrivateMethods: no exception raised for initPagination with missing field name ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testPrivateMethods: exception properly raised for initPagination with missing field name ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         Test.stopTest();
@@ -576,78 +577,78 @@ public class  sfpegList_TST {
     /***
     * @description  Test method for the sfpegList_SVC virtual class, checking the 3 methods
     *               providing default implementation (for code coverage).
-    *               It does the sames on default cases of the sfpegListTest_SVC test 
+    *               It does the sames on default cases of the sfpegListTest_SVC test
     *               implementation
     * @see  sfpegList_SVC
     * @see  sfpegListTest_SVC
     ***/
 
     static TestMethod void testVirtualApexClass() {
-        System.debug('testVirtualApexClass: START'); 
+        System.debug('testVirtualApexClass: START');
         Test.startTest();
 
         sfpegListQuery_SVC newInstance = new sfpegListQuery_SVC();
         sfpegListTest_SVC newInstanceT = new sfpegListTest_SVC();
-        System.debug('testVirtualApexClass: newInstance init '); 
+        System.debug('testVirtualApexClass: newInstance init ');
 
         try {
             newInstance.getData(null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getData ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getData ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         try {
             newInstanceT.getData(null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getData on TEST ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getData on TEST ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
-        
+
         try {
             newInstance.getCount(null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getCount ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getCount ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         try {
             newInstanceT.getCount(null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getCount on TEST ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getCount on TEST ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         try {
             newInstance.getPaginatedData(null,null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getPaginatedData ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getPaginatedData ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         try {
             newInstanceT.getPaginatedData(null,null,null);
             System.debug(LoggingLevel.Error,'testVirtualApexClass: no exception raised for getPaginatedData on Test ');
-            System.assert(false);      
+            System.assert(false);
         }
         catch (Exception e) {
             System.debug('testVirtualApexClass: exception properly raised for getPaginatedData ' + e.getMessage());
-            System.assert(true);      
+            System.assert(true);
         }
 
         Test.stopTest();
@@ -661,18 +662,18 @@ public class  sfpegList_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegListSelector_CTL controller = new sfpegListSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -687,18 +688,18 @@ public class  sfpegList_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'Opportunity';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegListSelector_CTL controller = new sfpegListSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegMergeLabels_CTL.cls
+++ b/force-app/main/default/classes/sfpegMergeLabels_CTL.cls
@@ -9,21 +9,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegMergeLabels_CTL {
 
     /***
@@ -100,7 +101,7 @@ public with sharing class sfpegMergeLabels_CTL {
             });
         Map<String, Object> returnMap = (Map<String, Object>)JSON.deserializeUntyped((ref.getContent()).tostring());
         returnMap.remove('END');
-        
+
         System.debug('getLabels: END - returning returnMap ' + returnMap);
         return returnMap;
     }*/

--- a/force-app/main/default/classes/sfpegMerge_CTL.cls
+++ b/force-app/main/default/classes/sfpegMerge_CTL.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +31,9 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegMerge_CTL {
-    
+
     /***
     * @description  Method to fetch configuration values for the merge service.
     *               For a list of configuration data grouped by domain, it provides
@@ -63,7 +64,7 @@ public with sharing class sfpegMerge_CTL {
         }
         System.debug('getValues: refMap init ' + refMap);
 
-        
+
         Map<String,Object> returnMap = new Map<String,Object>();
         for (Object iter : configMap.keySet()) {
             System.debug('getValues: processing iter ' + iter);
@@ -77,7 +78,7 @@ public with sharing class sfpegMerge_CTL {
             }
             System.debug('getValues: #Items to process ' + iterList.size());
 
-            
+
             switch on (String)iter {
                 when 'VFP' {
                     System.debug('getValues: processing VF page URLs');
@@ -111,7 +112,7 @@ public with sharing class sfpegMerge_CTL {
                 }
                 when 'RT' {
                     System.debug('getValues: processing Record Types');
-                
+
                     for (Object iterRT : iterList) {
                         System.debug(LoggingLevel.FINE,'getValues: processing RT ' + iterRT);
 
@@ -154,7 +155,7 @@ public with sharing class sfpegMerge_CTL {
                 }
                 when else {
                     System.debug('getValues: processing registered query');
-                    
+
                     sfpegConfiguration__mdt iterConfig = refMap.get((String)iter);
                     if (iterConfig == null) {
                         System.debug(LoggingLevel.WARN,'getValues: END - Unsupported configuration provided for key ' + iter);

--- a/force-app/main/default/classes/sfpegMerge_TST.cls
+++ b/force-app/main/default/classes/sfpegMerge_TST.cls
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,8 +33,9 @@
 ***/
 
 @isTest
-public class  sfpegMerge_TST {
-    
+@SuppressWarnings('PMD.ClassNamingConventions')
+public class sfpegMerge_TST {
+
     /***
     * @description Initializes the test context.
     ***/
@@ -48,7 +49,7 @@ public class  sfpegMerge_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -66,7 +67,7 @@ public class  sfpegMerge_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -75,13 +76,13 @@ public class  sfpegMerge_TST {
     *               with all configuration data possible (VFP, RT, PERM, NPERM, custom
     *               tokens like RPT), including all error cases.
     *               LBL token cannot be tested due to test class constraint preventing from rendering
-    *               the underlying sfpegMergeLabels_VFP page. --> sfpegMergeLabels_CCTL tested 
+    *               the underlying sfpegMergeLabels_VFP page. --> sfpegMergeLabels_CCTL tested
     *               separately and directly.
     * @see  sfpegMerge_CTL
     ***/
-    
+
     static TestMethod void testGetConfig() {
-        System.debug('testGetConfig: START'); 
+        System.debug('testGetConfig: START');
         Test.startTest();
 
         try {
@@ -170,7 +171,7 @@ public class  sfpegMerge_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfig: END');    
+		System.debug('testGetConfig: END');
     }
 
 
@@ -181,7 +182,7 @@ public class  sfpegMerge_TST {
     ***/
 
     static TestMethod void testGetRecord() {
-        System.debug('testGetRecord: START'); 
+        System.debug('testGetRecord: START');
         Test.startTest();
 
         sfpegTestObject__c testRecord = new sfpegTestObject__c(Name = 'TEST');
@@ -191,48 +192,48 @@ public class  sfpegMerge_TST {
 
         try {
 	        Object recordData = sfpegMerge_CTL.getRecord('DUMMY_OBJECT', 'DUMMY_ID', new List<String>());
-            System.debug(LoggingLevel.Error,'testGetRecord: no error raised for for missing field names'); 
+            System.debug(LoggingLevel.Error,'testGetRecord: no error raised for for missing field names');
             System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetRecord: error properly raised for missing field names ' + e.getMessage());
-            System.assert(true);          
+            System.assert(true);
         }
 
         try {
             Object recordData = sfpegMerge_CTL.getRecord('sfpegTestObject__c',testRecordId, new List<String>{'Name'});
-            System.debug('testGetRecord: no error raised for proper record'); 
+            System.debug('testGetRecord: no error raised for proper record');
             System.assert(true);
         }
         catch (Exception e) {
             System.debug(LoggingLevel.Error,'testGetRecord: unexpected error raised for proper record ' + e.getMessage());
-            System.assert(false);               
+            System.assert(false);
         }
-         
+
         delete testRecord;
-        System.debug('testGetRecord: testRecord deleted '); 
+        System.debug('testGetRecord: testRecord deleted ');
         try {
             Object recordData = sfpegMerge_CTL.getRecord('sfpegTestObject__c',testRecordId, new List<String>{'Name'});
-            System.debug(LoggingLevel.Error,'testGetRecord: no error raised for deleted record'); 
+            System.debug(LoggingLevel.Error,'testGetRecord: no error raised for deleted record');
             System.assert(false);
         }
         catch (Exception e) {
             System.debug('testGetRecord: error properly raised for deleted record ' + e.getMessage());
-            System.assert(true);               
+            System.assert(true);
         }
 
         Test.stopTest();
-		System.debug('testGetRecord: END'); 
+		System.debug('testGetRecord: END');
     }
 
     /***
-    * @description  Test method for the sfpegMerge_CTL class, checking the 
+    * @description  Test method for the sfpegMerge_CTL class, checking the
     *               "replaceLabelTokens" method, including all error cases.
     * @see  sfpegMerge_CTL
     ***/
 
     static TestMethod void testReplaceLabelTokens() {
-        System.debug('testReplaceLabelTokens: START'); 
+        System.debug('testReplaceLabelTokens: START');
         Test.startTest();
 
         // No token case
@@ -247,18 +248,18 @@ public class  sfpegMerge_TST {
         System.debug('testReplaceLabelTokens: template with two tokens merged ' + mergedTemplate);
         System.assert(!mergedTemplate.contains('{{{LBL'),'All LBL tokens have not been merged');
 
-        System.debug('testReplaceLabelTokens: END'); 
+        System.debug('testReplaceLabelTokens: END');
     }
 
 
     /***
-    * @description  Test method for the sfpegMerge_CTL class, checking the 
+    * @description  Test method for the sfpegMerge_CTL class, checking the
     *               "replaceFieldLabelTokens" method, including all error cases.
     * @see  sfpegMerge_CTL
     ***/
 
     static TestMethod void testReplaceFieldLabelTokens() {
-        System.debug('testReplaceFieldLabelTokens: START'); 
+        System.debug('testReplaceFieldLabelTokens: START');
         Test.startTest();
 
         // No token case
@@ -284,7 +285,7 @@ public class  sfpegMerge_TST {
             System.debug('testReplaceFieldLabelTokens: unknown FLBL token properly detected / ' + e.getMessage());
             System.assert(true);
         }
-        System.debug('testReplaceFieldLabelTokens: END'); 
+        System.debug('testReplaceFieldLabelTokens: END');
     }
 
 
@@ -299,20 +300,20 @@ public class  sfpegMerge_TST {
     * @see  sfpegMergeLabel_CTL
     * @see  sfpegMergeLabels_VFP
     ***/
-    
+
     static TestMethod void testGetMergeLabel() {
-        System.debug('testGetMergeLabel: START'); 
+        System.debug('testGetMergeLabel: START');
         Test.startTest();
 
         try {
             PageReference mergeVFP = Page.sfpegMergeLabels_VFP;
             Test.setCurrentPage(mergeVFP);
             ApexPages.currentPage().getParameters().put('labels','["Label1","Label2"]');
-            System.debug('testGetMergeLabel: current page set with labels parameter '); 
+            System.debug('testGetMergeLabel: current page set with labels parameter ');
 
             sfpegMergeLabels_CTL mergeCTL = new sfpegMergeLabels_CTL();
             System.debug('testGetMergeLabel: controller instantiated ');
-        
+
             List<String> labelList = mergeCTL.getLabelNames();
             System.debug('testGetMergeLabel: labelNames fetched ' + labelList);
             System.assert(true);
@@ -323,7 +324,7 @@ public class  sfpegMerge_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfig: END');    
+		System.debug('testGetConfig: END');
     }
 
 }

--- a/force-app/main/default/classes/sfpegMessageSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegMessageSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              Message configurations registered in the sfpegMessage__mdt custom metadata
 *              and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegMessageSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
     VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
     global sfpegMessageSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
         System.debug(LoggingLevel.FINEST,'Constructor START with sfpegMessage page context ' + pageContext);
         System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
         this.pageContext = pageContext;
     }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,41 +63,41 @@ global with sharing class sfpegMessageSelector_CTL extends VisualEditor.DynamicP
         System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
         return new VisualEditor.DataRow('---','N/A');
     }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
     global override VisualEditor.DynamicPickListRows getValues() {
         System.debug(LoggingLevel.FINEST,'getValues: START for sfpegMessage');
-    
+
         VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
         picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
         System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
-    
+
+
         System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
         Map<ID,sfpegMessage__mdt> queries = new Map<ID,sfpegMessage__mdt>(
             [   select MasterLabel,  DeveloperName
-                from sfpegMessage__mdt 
+                from sfpegMessage__mdt
                 where Scope__c LIKE '%GLOBAL%'  ]);
         if (! String.isEmpty(pageContext.entityName)) {
             System.debug(LoggingLevel.FINEST,'getValues: fetching GLOBAL, Record and object specific queries');
             queries.putAll(new Map<ID,sfpegMessage__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegMessage__mdt 
+                    from sfpegMessage__mdt
                     where Scope__c LIKE '%RECORDS%']));
             String entityPattern = '%' + pageContext.entityName + '%';
             queries.putAll(new Map<ID,sfpegMessage__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegMessage__mdt 
+                    from sfpegMessage__mdt
                     where Scope__c LIKE :entityPattern]));
         }
         System.debug(LoggingLevel.FINEST,'getValues: queries initialized ' + queries);
-    
+
         for (ID iter : queries.keySet()){
             sfpegMessage__mdt queryIter = queries.get(iter);
             System.debug(LoggingLevel.FINEST,'getValues: processing query ' + queryIter);

--- a/force-app/main/default/classes/sfpegMessage_CTL.cls
+++ b/force-app/main/default/classes/sfpegMessage_CTL.cls
@@ -6,21 +6,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,8 +30,9 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegMessage_CTL {
-    
+
     /***
     * @description  Simple method to fetch configuration details for a Message List component.
     *               It provides the display configuration as well as the actions available.

--- a/force-app/main/default/classes/sfpegMessage_TST.cls
+++ b/force-app/main/default/classes/sfpegMessage_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
-public class  sfpegMessage_TST {
-    
+@SuppressWarnings('PMD.ClassNamingConventions')
+public class sfpegMessage_TST {
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class  sfpegMessage_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -65,7 +66,7 @@ public class  sfpegMessage_TST {
 
         insert newAssignments;
         System.debug('testSetup: newAssignments inserted ' + newAssignments);
-        
+
         System.debug('testSetup: END');
     }
 
@@ -75,9 +76,9 @@ public class  sfpegMessage_TST {
     *               check OK case.
     * @see  sfpegMessage_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public class  sfpegMessage_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
 
@@ -112,18 +113,18 @@ public class  sfpegMessage_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegMessageSelector_CTL controller = new sfpegMessageSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -138,18 +139,18 @@ public class  sfpegMessage_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegMessageSelector_CTL controller = new sfpegMessageSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegProfileSelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegProfileSelector_CTL.cls
@@ -1,5 +1,5 @@
 /***
-* @description Lightning controller for the App Builder to provide the list of 
+* @description Lightning controller for the App Builder to provide the list of
 *              Record Profile configurations registered in the sfpegProfile__mdt custom
 *              metadat and available on the current Object type, for use in a configuration
 *              attribute data source (to display a picklist).
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegProfileSelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
     VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
     global sfpegProfileSelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
         System.debug(LoggingLevel.FINEST,'Constructor START with sfpegProfile page context ' + pageContext);
         System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
         this.pageContext = pageContext;
     }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,37 +63,37 @@ global with sharing class sfpegProfileSelector_CTL extends VisualEditor.DynamicP
         System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
         return new VisualEditor.DataRow('---','N/A');
     }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
     global override VisualEditor.DynamicPickListRows getValues() {
         System.debug(LoggingLevel.FINEST,'getValues: START for sfpegProfile');
-    
+
         VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
         picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
         System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
+
         System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
         Map<ID,sfpegProfile__mdt> profiles = new Map<ID,sfpegProfile__mdt>();
         if (! String.isEmpty(pageContext.entityName)) {
             System.debug(LoggingLevel.FINEST,'getValues: fetching Record and object specific profiles');
             profiles.putAll(new Map<ID,sfpegProfile__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegProfile__mdt 
+                    from sfpegProfile__mdt
                     where Scope__c LIKE '%RECORDS%']));
             String entityPattern = '%' + pageContext.entityName + '%';
             profiles.putAll(new Map<ID,sfpegProfile__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegProfile__mdt 
+                    from sfpegProfile__mdt
                     where Scope__c LIKE :entityPattern]));
         }
         System.debug(LoggingLevel.FINEST,'getValues: profiles initialized ' + profiles);
-    
+
         for (ID iter : profiles.keySet()){
             sfpegProfile__mdt profileIter = profiles.get(iter);
             System.debug(LoggingLevel.FINEST,'getValues: processing profile ' + profileIter);

--- a/force-app/main/default/classes/sfpegProfile_CTL.cls
+++ b/force-app/main/default/classes/sfpegProfile_CTL.cls
@@ -6,21 +6,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,8 +30,9 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegProfile_CTL {
-    
+
     /***
     * @description  Simple method to fetch configuration details for a Record Profile component.
     *               It provides the display configuration as well as the actions available.
@@ -48,12 +49,12 @@ public with sharing class sfpegProfile_CTL {
                                                     ProfileActions__c, ProfileDetails__c
                                             FROM sfpegProfile__mdt
                                             WHERE DeveloperName =  :name];
-        
+
         if ((configs == null) || (configs.size() != 1)) {
             System.debug(LoggingLevel.ERROR,'getConfiguration: END KO / configuration not found with name ' + name);
             throw new AuraHandledException('Configuration not found with name ' + name);
         }
-        
+
         //System.debug(LoggingLevel.FINEST,'getConfiguration: END with configuration name ' + configs[0]);
         System.debug(LoggingLevel.FINE,'getConfiguration: END ' + configs[0].MasterLabel);
         return (Object) (configs[0]);

--- a/force-app/main/default/classes/sfpegProfile_TST.cls
+++ b/force-app/main/default/classes/sfpegProfile_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,9 @@
 ***/
 
 @isTest
-public class  sfpegProfile_TST {
-    
+@SuppressWarnings('PMD.ClassNamingConventions')
+public class sfpegProfile_TST {
+
     /***
     * @description Initializes the test context.
     ***/
@@ -47,7 +48,7 @@ public class  sfpegProfile_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -75,9 +76,9 @@ public class  sfpegProfile_TST {
     *               check OK case.
     * @see  sfpegProfile_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public class  sfpegProfile_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
 
@@ -112,18 +113,18 @@ public class  sfpegProfile_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegProfileSelector_CTL controller = new sfpegProfileSelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -138,18 +139,18 @@ public class  sfpegProfile_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegProfileSelector_CTL controller = new sfpegProfileSelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 

--- a/force-app/main/default/classes/sfpegRecordDisplaySelector_CTL.cls
+++ b/force-app/main/default/classes/sfpegRecordDisplaySelector_CTL.cls
@@ -1,6 +1,6 @@
 /***
-* @description  Lightning controller for the App Builder to provide the list of 
-*               Record Display configurations registered in the sfpegRecordDisplay__mdt 
+* @description  Lightning controller for the App Builder to provide the list of
+*               Record Display configurations registered in the sfpegRecordDisplay__mdt
 *               custom metadata and available on the current Object type, for use in a
 *               configuration attribute data source (to display a picklist).
 * @author       P-E GROS
@@ -8,21 +8,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,27 +32,28 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 global with sharing class sfpegRecordDisplaySelector_CTL extends VisualEditor.DynamicPickList {
 
     /***
     * @description Context of the Lightning page calling the picklist controller.
     ***/
     VisualEditor.DesignTimePageContext pageContext;
-    
+
     /***
     * @description Constructor enabling to fetch the Lightning page context (and especially
     *              the entityName of the record being displayed in the page).
     * @param       VisualEditor.DesignTimePageContext   Current page context
     * @exception   none really specific.
-    ***/    
-    
+    ***/
+
     global sfpegRecordDisplaySelector_CTL(VisualEditor.DesignTimePageContext pageContext) {
         System.debug(LoggingLevel.FINEST,'Constructor START with sfpegRecordDisplay page context ' + pageContext);
         System.debug(LoggingLevel.FINEST,'Constructor entityName ' + pageContext.entityName);
         this.pageContext = pageContext;
     }
-    
-    
+
+
     /***
     * @description Override of the method providing the default value.
     * @return      VisualEditor.DataRow   Always returns the default ('---','N/A') value.
@@ -62,36 +63,36 @@ global with sharing class sfpegRecordDisplaySelector_CTL extends VisualEditor.Dy
         System.debug(LoggingLevel.FINEST,'getDefaultValue START Number');
         return new VisualEditor.DataRow('---','N/A');
     }
-        
+
     /***
     * @description Override of the method providing the set of picklist values.
-    *              Returns label / names couples for all field sets 
+    *              Returns label / names couples for all field sets
     *              defined on entity. Includes a default ('---','N/A') value.
     * @return      VisualEditor.DynamicPickListRows  List of field set names for datasource.
     * @exception   none really specific.
     ***/
     global override VisualEditor.DynamicPickListRows getValues() {
         System.debug(LoggingLevel.FINEST,'getValues: START for sfpegRecordDisplay');
-    
+
         VisualEditor.DynamicPickListRows picklistValues = new VisualEditor.DynamicPickListRows();
         picklistValues.addRow(new VisualEditor.DataRow('---','N/A'));
         System.debug(LoggingLevel.FINEST,'getValues: picklistValues init ' + picklistValues);
-    
+
         System.debug(LoggingLevel.FINEST,'getValues: entity name fetched ' + pageContext.entityName);
         Map<ID,sfpegRecordDisplay__mdt> configurations = new Map<ID,sfpegRecordDisplay__mdt>(
             [   select MasterLabel,  DeveloperName
-                from sfpegRecordDisplay__mdt 
+                from sfpegRecordDisplay__mdt
                 where Scope__c LIKE '%RECORDS%']);
         if (! String.isEmpty(pageContext.entityName)) {
             System.debug(LoggingLevel.FINEST,'getValues: fetching Record and object specific queries');
             String entityPattern = '%' + pageContext.entityName + '%';
             configurations.putAll(new Map<ID,sfpegRecordDisplay__mdt>(
                 [   select MasterLabel,  DeveloperName
-                    from sfpegRecordDisplay__mdt 
+                    from sfpegRecordDisplay__mdt
                     where Scope__c LIKE :entityPattern]));
         }
         System.debug(LoggingLevel.FINEST,'getValues: configurations initialized ' + configurations);
-    
+
         for (ID iter : configurations.keySet()){
             sfpegRecordDisplay__mdt configIter = configurations.get(iter);
             System.debug(LoggingLevel.FINEST,'getValues: processing query ' + configIter);

--- a/force-app/main/default/classes/sfpegRecordDisplay_CTL.cls
+++ b/force-app/main/default/classes/sfpegRecordDisplay_CTL.cls
@@ -6,21 +6,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,6 +30,7 @@
 * SOFTWARE.
 ***/
 
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegRecordDisplay_CTL {
 
     /***
@@ -47,12 +48,12 @@ public with sharing class sfpegRecordDisplay_CTL {
         List<sfpegRecordDisplay__mdt> configs = [   SELECT  MasterLabel, DisplayConfig__c
                                                     FROM sfpegRecordDisplay__mdt
                                                     WHERE DeveloperName =  :name    ];
-        
+
         if ((configs == null) || (configs.size() != 1)) {
             System.debug(LoggingLevel.ERROR,'getConfiguration: END KO / configuration not found with name ' + name);
             throw new AuraHandledException('Configuration not found with name ' + name);
         }
-        
+
         if ((configs[0]?.DisplayConfig__c)?.contains('{{{LBL.')) {
             System.debug(LoggingLevel.FINE,'getConfiguration: extracting/replacing custom labels in display config');
             configs[0].DisplayConfig__c = sfpegMerge_CTL.replaceLabelTokens(configs[0].DisplayConfig__c);
@@ -70,7 +71,7 @@ public with sharing class sfpegRecordDisplay_CTL {
         else {
             System.debug(LoggingLevel.FINE,'getConfiguration: no field label in display config');
         }
-        
+
         System.debug(LoggingLevel.FINE,'getConfiguration: END ' + configs[0].MasterLabel);
         return (Object) (configs[0]);
     }

--- a/force-app/main/default/classes/sfpegRecordDisplay_TST.cls
+++ b/force-app/main/default/classes/sfpegRecordDisplay_TST.cls
@@ -7,21 +7,21 @@
 * @see PEG_LIST package (https://github.com/pegros/PEG_LIST)
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2021 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,6 +32,7 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegRecordDisplay_TST {
 
     /***
@@ -47,7 +48,7 @@ public with sharing class sfpegRecordDisplay_TST {
         Map<ID,PermissionSet> sfpegPSets = new Map<ID,PermissionSet>([SELECT Id, Name FROM PermissionSet WHERE Name LIKE 'sfpeg%']);
         System.debug('testSetup: sfpegPSets fetched ' + sfpegPSets);
 
-        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment 
+        List<PermissionSetAssignment> currentAssignments = [    select PermissionSetId from PermissionSetAssignment
                                                                 where AssigneeId = :currentUserId and PermissionSetId in :sfpegPSets.keySet()];
         System.debug('testSetup: currentAssignments fetched ' + currentAssignments);
         for (PermissionSetAssignment iter : currentAssignments) {
@@ -75,9 +76,9 @@ public with sharing class sfpegRecordDisplay_TST {
     *               check OK case.
     * @see  sfpegRecordDisplay_CTL
     ***/
-    
+
     static TestMethod void testGetConfiguration() {
-        System.debug('testGetConfiguration: START'); 
+        System.debug('testGetConfiguration: START');
         Test.startTest();
 
         try {
@@ -101,7 +102,7 @@ public with sharing class sfpegRecordDisplay_TST {
         }
 
         Test.stopTest();
-		System.debug('testGetConfiguration: END');    
+		System.debug('testGetConfiguration: END');
     }
 
 
@@ -112,18 +113,18 @@ public with sharing class sfpegRecordDisplay_TST {
     ***/
 
     static TestMethod void testGetDefaultValue() {
-        System.debug('testGetDefaultValue: START'); 
+        System.debug('testGetDefaultValue: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetDefaultValue: testContext init'); 
+        System.debug('testGetDefaultValue: testContext init');
 
         sfpegRecordDisplaySelector_CTL controller = new sfpegRecordDisplaySelector_CTL(testContext);
-        System.debug('testGetDefaultValue: controller init'); 
-    
+        System.debug('testGetDefaultValue: controller init');
+
         VisualEditor.DataRow defVal = controller.getDefaultValue();
-        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal); 
+        System.debug('testGetDefaultValue: getDefaultValue called ' + defVal);
 
         System.assertEquals('N/A',defVal.getValue());
 
@@ -138,18 +139,18 @@ public with sharing class sfpegRecordDisplay_TST {
     ***/
 
     static TestMethod void testGetValues() {
-        System.debug('testGetValues: START'); 
+        System.debug('testGetValues: START');
         Test.startTest();
 
         VisualEditor.DesignTimePageContext  testContext = new VisualEditor.DesignTimePageContext();
         testContext.entityName =  'sfpegTestObject__c';
-        System.debug('testGetValues: testContext init'); 
+        System.debug('testGetValues: testContext init');
 
         sfpegRecordDisplaySelector_CTL controller = new sfpegRecordDisplaySelector_CTL(testContext);
-        System.debug('testGetValues: controller init'); 
-    
+        System.debug('testGetValues: controller init');
+
         VisualEditor.DynamicPickListRows listVal = controller.getValues();
-        System.debug('testGetValues: getValues called ' + listVal); 
+        System.debug('testGetValues: getValues called ' + listVal);
 
         System.assert(listVal.size() > 0);
 


### PR DESCRIPTION
Add @SuppressWarnings('PMD.[ClassNamingConventions](https://pmd.github.io/latest/pmd_userdocs_suppressing_warnings.html)') to prevent references issues on legacy installs