### PR TITLE
Don't show hidden sub-items in the dropdown

### DIFF
--- a/force-app/main/default/lwc/sfpegActionBarCmp/sfpegActionBarCmp.html
+++ b/force-app/main/default/lwc/sfpegActionBarCmp/sfpegActionBarCmp.html
@@ -355,19 +355,21 @@
                                                                                 if:false={itermenu.value.label}>
                                                     </lightning-menu-subheader>
                                                     <template for:each={itermenu.value.items} for:item="iterMenu2" >
-                                                        <lightning-menu-item    key={iterMenu2.name}
-                                                                                label={iterMenu2.label}
-                                                                                icon-name={iterMenu2.iconName}
-                                                                                value={iterMenu2}
-                                                                                if:false={iterMenu2.disabled}>
-                                                         </lightning-menu-item>
-                                                         <lightning-menu-item   key={iterMenu2.name}
-                                                                                label={iterMenu2.label}
-                                                                                icon-name={iterMenu2.iconName}
-                                                                                value={iterMenu2}
-                                                                                disabled
-                                                                                if:true={iterMenu2.disabled}>
-                                                         </lightning-menu-item>
+                                                        <template if:false={iterMenu2.hidden}>
+                                                            <lightning-menu-item    key={iterMenu2.name}
+                                                                                    label={iterMenu2.label}
+                                                                                    icon-name={iterMenu2.iconName}
+                                                                                    value={iterMenu2}
+                                                                                    if:false={iterMenu2.disabled}>
+                                                             </lightning-menu-item>
+                                                             <lightning-menu-item   key={iterMenu2.name}
+                                                                                    label={iterMenu2.label}
+                                                                                    icon-name={iterMenu2.iconName}
+                                                                                    value={iterMenu2}
+                                                                                    disabled
+                                                                                    if:true={iterMenu2.disabled}>
+                                                             </lightning-menu-item>
+                                                        </template>
                                                     </template>
                                                     <lightning-menu-divider     key={itermenu.value.name}
                                                                                 if:false={itermenu.last}>


### PR DESCRIPTION
When a button with sub-buttons is added in the sfpegActionBarCmp and this button is displayed in the dropdown (no place is available for this button), the hidden sub-buttons are not hidden in the dropdown.